### PR TITLE
updated less dependency - fixes #14

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
     'coffeescript',
     'underscore',
     'templating',
-    'less',
+    'less@1.0.0 || 2.5.0',
     'jquery',
     'reactive-dict',
     'aldeed:autoform@5.3.0',


### PR DESCRIPTION
Resolves less dependency, allows Meteor 1.2+ to use the latest version of autoform-slingshot
